### PR TITLE
Add sleep command after closing existing PRs.

### DIFF
--- a/tests/ProjectCommandsTest.php
+++ b/tests/ProjectCommandsTest.php
@@ -48,6 +48,8 @@ class ProjectCommandsTest extends CommandsTestBase
 
         // Close the open pull requests.
         $this->fixtures()->closeAllOpenPullRequests('drops-8');
+        // Make sure github API has enough time to realize the PR has been closed
+        sleep(5);
 
         // Verify the latest releast in our drops-8 and drupal fixtures.
         $output = $this->executeExpectOK(['project:latest', 'drops-8']);
@@ -117,6 +119,9 @@ class ProjectCommandsTest extends CommandsTestBase
     {
         // Closes any leftover PRs in the fixture repository.
         $this->fixtures()->closeAllOpenPullRequests('wp');
+
+        // Make sure github API has enough time to realize the PR has been closed
+        sleep(5);
 
         // Create a fork
 //        $wp_repo = $this->fixtures()->forkTestRepo('wp');


### PR DESCRIPTION
### Overview
This pull request makes tests less fragile.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Adds sleep after closing PRs to ensure it doesn't conflict in the next steps of the test.