### PR TITLE
CMS-434: Update org:analyze command to add support_level.

### DIFF
--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -18,6 +18,7 @@ use Hubph\VersionIdentifiers;
 use Hubph\PullRequests;
 use Hubph\Git\WorkingCopy;
 use Hubph\Git\Remote;
+use UpdateTool\Util\SupportLevel;
 
 class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwareInterface
 {
@@ -88,7 +89,8 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
      *   codeowners: Code Owners
      *   owners_src: Owners Source
      *   ownerTeam: Owning Team
-     * @default-fields full_name,codeowners,owners_src
+     *   support_level: Support Level
+     * @default-fields full_name,codeowners,owners_src,support_level
      * @default-string-field full_name
      *
      * @return Consolidation\OutputFormatters\StructuredData\RowsOfFields
@@ -137,6 +139,15 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                 $repo['ownerTeam'] = str_replace("@$org/", "", $codeowners[0]);
             }
 
+            try {
+                $data = $api->gitHubAPI()->api('repo')->contents()->show($org, $repo['name'], 'README.md');
+                if (!empty($data['content'])) {
+                    $content = base64_decode($data['content']);
+                    $repo['support_level'] = static::getSupportLevel($content);
+                }
+            } catch (\Exception $e) {
+            }
+
             $reposResult[$resultKey] = $repo;
         }
 
@@ -144,6 +155,28 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         $this->addTableRenderFunction($data);
 
         return $data;
+    }
+
+    /**
+     * Get support level from README.md contents.
+     */
+    protected static function getSupportLevel($readme_contents)
+    {
+        $support_level = null;
+        $lines = explode("\n", $readme_contents);
+        $badges = SupportLevel::getSupportLevelBadges();
+        foreach ($lines as $line) {
+            foreach ($badges as $key => $badge) {
+                if (strpos($line, $badge) !== false) {
+                    $support_level = $key;
+                    break 2;
+                }
+            }
+        }
+        if ($support_level) {
+            return SupportLevel::getSupportLevelLabel($support_level);
+        }
+        return null;
     }
 
     protected static function inferOwners($api, $org, $project, $codeowners, $ownerSource)

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -141,9 +141,13 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         $badges = SupportLevel::getSupportLevelBadges();
         foreach ($lines as $line) {
             foreach ($badges as $key => $badge) {
-                if (strpos($line, $badge) !== false) {
-                    $support_level = $key;
-                    break 2;
+                // Get the badge text from the badge markup.
+                preg_match('/^\[\!\[([A-Za-z\s\d]+)\]\(https:\/\/img.shields.io/', $badge, $matches);
+                if (!empty($matches[1])) {
+                    if (strpos($line, $matches[1]) !== false) {
+                        $support_level = $key;
+                        break 2;
+                    }
                 }
             }
         }

--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -18,6 +18,7 @@ use UpdateTool\Git\WorkingCopy;
 use UpdateTool\Update\Filters\FilterManager;
 use UpdateTool\Util\ReleaseNode;
 use VersionTool\VersionTool;
+use UpdateTool\Util\SupportLevel;
 
 /**
  * Commands used to manipulate projects directly with git
@@ -578,7 +579,7 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
 
         if (!empty($options['support-level-badge'])) {
             $support_level_badge = $options['support-level-badge'];
-            $badge_contents = $this->getSupportLevelBadge($support_level_badge);
+            $badge_contents = SupportLevel::getSupportLevelBadge($support_level_badge);
             if (!$badge_contents) {
                 throw new \Exception("Invalid support level badge: $support_level_badge.");
             }
@@ -659,23 +660,6 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
             }
         }
         return [$badge_insert_line, $empty_line_after];
-    }
-
-    /**
-     * Get right badge markdown.
-     */
-    protected function getSupportLevelBadge($level)
-    {
-        $badges = [
-            'ea' => '[![Early Access](https://img.shields.io/badge/pantheon-EARLY_ACCESS-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/early-access?q=org%3Apantheon-systems)',
-            'la' => '[![Limited Availability](https://img.shields.io/badge/pantheon-LIMITED_AVAILABILTY-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/limited-availability?q=org%3Apantheon-systems)',
-            'actively-supported' => '[![Actively Maintained](https://img.shields.io/badge/pantheon-actively_maintained-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/actively-maintained?q=org%3Apantheon-systems)',
-            'minimally-supported' => '[![Minimal Support](https://img.shields.io/badge/pantheon-minimal_support-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/minimal-support?q=org%3Apantheon-systems)',
-            'unsupported' => '[![Unsupported](https://img.shields.io/badge/pantheon-unsupported-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/unsupported?q=org%3Apantheon-systems)',
-            'unofficial' => '[![Unofficial](https://img.shields.io/badge/pantheon-unofficial-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/unofficial?q=org%3Apantheon-systems)',
-            'deprecated' => '[![Deprecated](https://img.shields.io/badge/pantheon-deprecated-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/unofficial?q=org%3Apantheon-systems)',
-        ];
-        return $badges[$level] ?? '';
     }
 
     /**

--- a/src/Util/SupportLevel.php
+++ b/src/Util/SupportLevel.php
@@ -1,0 +1,60 @@
+<?php
+namespace UpdateTool\Util;
+
+
+/**
+ * Support level related functions.
+ */
+class SupportLevel {
+
+    /**
+     * Get right badge markdown.
+     */
+    public static function getSupportLevelBadge($level)
+    {
+        $badges = self::getSupportLevelBadges();
+        return $badges[$level] ?? '';
+    }
+
+    /**
+     * Get all support level badges.
+     */
+    public static function getSupportLevelBadges()
+    {
+        return [
+            'ea' => '[![Early Access](https://img.shields.io/badge/pantheon-EARLY_ACCESS-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/early-access?q=org%3Apantheon-systems)',
+            'la' => '[![Limited Availability](https://img.shields.io/badge/pantheon-LIMITED_AVAILABILTY-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/limited-availability?q=org%3Apantheon-systems)',
+            'actively-supported' => '[![Actively Maintained](https://img.shields.io/badge/pantheon-actively_maintained-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/actively-maintained?q=org%3Apantheon-systems)',
+            'minimally-supported' => '[![Minimal Support](https://img.shields.io/badge/pantheon-minimal_support-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/minimal-support?q=org%3Apantheon-systems)',
+            'unsupported' => '[![Unsupported](https://img.shields.io/badge/pantheon-unsupported-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/unsupported?q=org%3Apantheon-systems)',
+            'unofficial' => '[![Unofficial](https://img.shields.io/badge/pantheon-unofficial-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/unofficial?q=org%3Apantheon-systems)',
+            'deprecated' => '[![Deprecated](https://img.shields.io/badge/pantheon-deprecated-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/unofficial?q=org%3Apantheon-systems)',
+        ];
+    }
+
+    /**
+     * Get badges human names.
+     */
+    public static function getBadgesLabels()
+    {
+        return [
+            'ea' => 'Early Access',
+            'la' => 'Limited Availability',
+            'actively-supported' => 'Actively Maintained',
+            'minimally-supported' => 'Minimal Support',
+            'unsupported' => 'Unsupported',
+            'unofficial' => 'Unofficial',
+            'deprecated' => 'Deprecated',
+        ];
+    }
+
+    /**
+     * Get label for given badge.
+     */
+    public static function getSupportLevelLabel($level)
+    {
+        $badges = self::getBadgesLabels();
+        return $badges[$level] ?? '';
+    }
+
+}

--- a/src/Util/SupportLevel.php
+++ b/src/Util/SupportLevel.php
@@ -1,11 +1,12 @@
 <?php
-namespace UpdateTool\Util;
 
+namespace UpdateTool\Util;
 
 /**
  * Support level related functions.
  */
-class SupportLevel {
+class SupportLevel
+{
 
     /**
      * Get right badge markdown.
@@ -56,5 +57,4 @@ class SupportLevel {
         $badges = self::getBadgesLabels();
         return $badges[$level] ?? '';
     }
-
 }


### PR DESCRIPTION
### Overview
This pull request adds support_level field to org:analyze command.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
New default field added to org:analyze command.

### Notes
 I tested this with a temporary small change using "users" API instead of "organizations" and running the command against my Github account and it's getting the right data for Support Level field.
