### PR TITLE
CMS-435: Add new org:update-projects-info command.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -34,7 +34,7 @@ consolidation/self-update                 1.2.0    MIT
 consolidation/version-tool                0.1.10   MIT      
 container-interop/container-interop       1.2.0    MIT      
 dflydev/dot-access-data                   v1.1.0   MIT      
-g1a/hubph                                 0.6.1    MIT      
+g1a/hubph                                 0.6.2    MIT      
 grasmash/expander                         1.0.0    MIT      
 guzzlehttp/guzzle                         6.5.5    MIT      
 guzzlehttp/promises                       1.5.1    MIT      

--- a/LICENSE
+++ b/LICENSE
@@ -34,7 +34,7 @@ consolidation/self-update                 1.2.0    MIT
 consolidation/version-tool                0.1.10   MIT      
 container-interop/container-interop       1.2.0    MIT      
 dflydev/dot-access-data                   v1.1.0   MIT      
-g1a/hubph                                 0.4.0    MIT      
+g1a/hubph                                 0.6.1    MIT      
 grasmash/expander                         1.0.0    MIT      
 guzzlehttp/guzzle                         6.5.5    MIT      
 guzzlehttp/promises                       1.5.1    MIT      

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "composer/semver": "^2.0",
         "consolidation/robo": "^2.0.5",
         "consolidation/version-tool": "^0.1.9",
-        "g1a/hubph": "^0.4",
+        "g1a/hubph": "^0.6",
         "php-http/guzzle6-adapter": "^1.1",
         "symfony/console": "^2.8|^3|^4",
         "tm/tooly-composer-script": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -754,16 +754,16 @@
         },
         {
             "name": "g1a/hubph",
-            "version": "0.6.1",
+            "version": "0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/g1a/hubph.git",
-                "reference": "06654e21a9a0e97712f756713a81e7f84738f603"
+                "reference": "a76fa40a3d240136f0dc5ea471b432465a856d29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/g1a/hubph/zipball/06654e21a9a0e97712f756713a81e7f84738f603",
-                "reference": "06654e21a9a0e97712f756713a81e7f84738f603",
+                "url": "https://api.github.com/repos/g1a/hubph/zipball/a76fa40a3d240136f0dc5ea471b432465a856d29",
+                "reference": "a76fa40a3d240136f0dc5ea471b432465a856d29",
                 "shasum": ""
             },
             "require": {
@@ -805,9 +805,9 @@
             "description": "Template project for PHP libraries.",
             "support": {
                 "issues": "https://github.com/g1a/hubph/issues",
-                "source": "https://github.com/g1a/hubph/tree/0.6.1"
+                "source": "https://github.com/g1a/hubph/tree/0.6.2"
             },
-            "time": "2021-12-02T00:43:18+00:00"
+            "time": "2021-12-06T21:20:37+00:00"
         },
         {
             "name": "grasmash/expander",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc696eb72668f4f43734c61307b8b049",
+    "content-hash": "775a950030adaf8728aa899d27a4e444",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -754,37 +754,37 @@
         },
         {
             "name": "g1a/hubph",
-            "version": "0.4.0",
+            "version": "0.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/g1a/hubph.git",
-                "reference": "9d727fbe20745f1333e8a433061cf519a0e71d38"
+                "reference": "06654e21a9a0e97712f756713a81e7f84738f603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/g1a/hubph/zipball/9d727fbe20745f1333e8a433061cf519a0e71d38",
-                "reference": "9d727fbe20745f1333e8a433061cf519a0e71d38",
+                "url": "https://api.github.com/repos/g1a/hubph/zipball/06654e21a9a0e97712f756713a81e7f84738f603",
+                "reference": "06654e21a9a0e97712f756713a81e7f84738f603",
                 "shasum": ""
             },
             "require": {
-                "consolidation/filter-via-dot-access-data": "^1",
-                "consolidation/robo": "^2.0.5",
+                "consolidation/filter-via-dot-access-data": "^1 || ^2",
+                "consolidation/robo": "^2.0.5 || ^3",
                 "knplabs/github-api": "^2.14",
                 "php": ">=7.1.3",
                 "php-http/guzzle6-adapter": "^1.1",
-                "symfony/console": "^2.8|^3|^4|^5",
-                "symfony/filesystem": "^2.8|^3|^4.4"
+                "symfony/console": "^2.8 || ^3 || ^4 || ^5",
+                "symfony/filesystem": "^2.8 || ^3 || ^4.4"
             },
             "require-dev": {
                 "g1a/composer-test-scenarios": "^2",
                 "phpunit/phpunit": "^5",
                 "satooshi/php-coveralls": "^2",
-                "squizlabs/php_codesniffer": "^2.8"
+                "squizlabs/php_codesniffer": "^3.6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.x-dev"
+                    "dev-main": "0.x-dev"
                 }
             },
             "autoload": {
@@ -805,9 +805,9 @@
             "description": "Template project for PHP libraries.",
             "support": {
                 "issues": "https://github.com/g1a/hubph/issues",
-                "source": "https://github.com/g1a/hubph/tree/0.4.0"
+                "source": "https://github.com/g1a/hubph/tree/0.6.1"
             },
-            "time": "2020-06-13T02:39:52+00:00"
+            "time": "2021-12-02T00:43:18+00:00"
         },
         {
             "name": "grasmash/expander",

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -107,7 +107,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                 $data = $api->gitHubAPI()->api('repo')->contents()->show($org, $repo['name'], 'README.md');
                 if (!empty($data['content'])) {
                     $content = base64_decode($data['content']);
-                    $repo['support_level'] = static::getSupportLevel($content);
+                    $repo['support_level'] = SupportLevel::getSupportLevelFromContent($content);
                 }
             } catch (\Exception $e) {
             }
@@ -239,32 +239,6 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
             }
         }
         return false;
-    }
-
-    /**
-     * Get support level from README.md contents.
-     */
-    protected static function getSupportLevel($readme_contents)
-    {
-        $support_level = null;
-        $lines = explode("\n", $readme_contents);
-        $badges = SupportLevel::getSupportLevelBadges();
-        foreach ($lines as $line) {
-            foreach ($badges as $key => $badge) {
-                // Get the badge text from the badge markup.
-                preg_match(SupportLevel::SUPPORT_LEVEL_BADGE_LABEL_REGEX, $badge, $matches);
-                if (!empty($matches[1])) {
-                    if (strpos($line, $matches[1]) !== false) {
-                        $support_level = $key;
-                        break 2;
-                    }
-                }
-            }
-        }
-        if ($support_level) {
-            return SupportLevel::getSupportLevelLabel($support_level);
-        }
-        return null;
     }
 
     protected static function inferOwners($api, $org, $project, $codeowners, $ownerSource)

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -202,7 +202,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                         $projectSupportLevel = null;
                     }
                     try {
-                      $this->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $prTitle, $options['pr-body'], $this->logger, $projectSupportLevel, $codeowners);
+                        $this->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $prTitle, $options['pr-body'], $this->logger, $projectSupportLevel, $codeowners);
                     } catch (\Exception $e) {
                         $this->logger->warning("Failed to update project information for $projectFullName: " . $e->getMessage());
                     }

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -142,7 +142,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         foreach ($lines as $line) {
             foreach ($badges as $key => $badge) {
                 // Get the badge text from the badge markup.
-                preg_match('/^\[\!\[([A-Za-z\s\d]+)\]\(https:\/\/img.shields.io/', $badge, $matches);
+                preg_match(SupportLevel::SUPPORT_LEVEL_BADGE_LABEL_REGEX, $badge, $matches);
                 if (!empty($matches[1])) {
                     if (strpos($line, $matches[1]) !== false) {
                         $support_level = $key;

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -138,7 +138,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         } catch (\Exception $e) {
         }
 
-       return static::inferOwners($api, $org, $repoName, $codeowners, $ownerSource);
+        return static::inferOwners($api, $org, $repoName, $codeowners, $ownerSource);
     }
 
     /**
@@ -213,7 +213,8 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
     /**
      * Validate project full name. Throw exception if invalid.
      */
-    protected function validateProjectFullName($projectFullName) {
+    protected function validateProjectFullName($projectFullName)
+    {
         if (empty($projectFullName)) {
             return false;
         }
@@ -227,7 +228,8 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
     /**
      * Validate project support level. Throw exception if invalid.
      */
-    protected function validateProjectSupportLevel($projectSupportLevel) {
+    protected function validateProjectSupportLevel($projectSupportLevel)
+    {
         $labels = SupportLevel::getBadgesLabels();
         foreach ($labels as $key => $label) {
             if ($projectSupportLevel === $label) {

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -166,6 +166,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         'branch-name' => 'project-update-info',
         'commit-message' => 'Update project information.',
         'pr-body' => '',
+        'pr-title' => '[UpdateTool - Project Information] Update project information.',
     ])
     {
         $api = $this->api($options['as']);
@@ -182,7 +183,6 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         if ($codeownersOnlyGuess && $codeownersOnlyApi) {
             throw new \Exception("--codeowners-only-api and --codeowners-only-guess can't be used together.");
         }
-        $prTitle = '[UpdateTool - Project Information] Update project information.';
         $branchName = $options['branch-name'];
         $commitMessage = $options['commit-message'];
         $projectUpdate = new ProjectUpdate($this->logger);
@@ -239,7 +239,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                         $projectSupportLevel = null;
                     }
                     try {
-                        $projectUpdate->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $prTitle, $options['pr-body'], $projectSupportLevel, $codeowners);
+                        $projectUpdate->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $options['pr-title'], $options['pr-body'], $projectSupportLevel, $codeowners);
                     } catch (\Exception $e) {
                         $this->logger->warning("Failed to update project information for $projectFullName: " . $e->getMessage());
                     }

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -201,7 +201,11 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                     if (!$projectUpdateSupportLevel) {
                         $projectSupportLevel = null;
                     }
-                    $this->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $prTitle, $options['pr-body'], $this->logger, $projectSupportLevel, $codeowners);
+                    try {
+                      $this->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $prTitle, $options['pr-body'], $this->logger, $projectSupportLevel, $codeowners);
+                    } catch (\Exception $e) {
+                        $this->logger->warning("Failed to update project information for $projectFullName: " . $e->getMessage());
+                    }
                 }
                 break;
             }

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -19,13 +19,12 @@ use Hubph\PullRequests;
 use Hubph\Git\WorkingCopy;
 use Hubph\Git\Remote;
 use UpdateTool\Util\SupportLevel;
-use UpdateTool\Util\ProjectUpdateTrait;
+use UpdateTool\Util\ProjectUpdate;
 
 class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwareInterface
 {
     use ConfigAwareTrait;
     use LoggerAwareTrait;
-    use ProjectUpdateTrait;
 
     /**
      * @command org:analyze
@@ -176,6 +175,8 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         $prTitle = '[UpdateTool - Project Information] Update project information.';
         $branchName = $options['branch-name'];
         $commitMessage = $options['commit-message'];
+        $projectUpdate = new ProjectUpdate($this->logger);
+
         if (file_exists($csv_file)) {
             $csv = new \SplFileObject($csv_file);
             $csv->setFlags(\SplFileObject::READ_CSV);
@@ -223,7 +224,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                         $projectSupportLevel = null;
                     }
                     try {
-                        $this->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $prTitle, $options['pr-body'], $this->logger, $projectSupportLevel, $codeowners);
+                        $projectUpdate->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $prTitle, $options['pr-body'], $projectSupportLevel, $codeowners);
                     } catch (\Exception $e) {
                         $this->logger->warning("Failed to update project information for $projectFullName: " . $e->getMessage());
                     }

--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -19,7 +19,7 @@ use UpdateTool\Update\Filters\FilterManager;
 use UpdateTool\Util\ReleaseNode;
 use VersionTool\VersionTool;
 use UpdateTool\Util\SupportLevel;
-use UpdateTool\Util\ProjectUpdateTrait;
+use UpdateTool\Util\ProjectUpdate;
 
 /**
  * Commands used to manipulate projects directly with git
@@ -29,7 +29,6 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
     use ConfigAwareTrait;
     use LoggerAwareTrait;
     use ApiTrait;
-    use ProjectUpdateTrait;
 
     /**
      * Show the list of available versions already released for the specified project.
@@ -552,7 +551,8 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
     ])
     {
         $api = $this->api($options['as']);
-        $this->updateProjectInfo($api, $project, $options['base-branch'], $options['branch-name'], $options['commit-message'], $options['pr-title'], $options['pr-body'], $this->logger, $options['support-level-badge'], $options['codeowners']);
+        $projectUpdate = new ProjectUpdate($this->logger);
+        $projectUpdate->updateProjectInfo($api, $project, $options['base-branch'], $options['branch-name'], $options['commit-message'], $options['pr-title'], $options['pr-body'], $options['support-level-badge'], $options['codeowners']);
     }
 
     /**

--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -19,6 +19,7 @@ use UpdateTool\Update\Filters\FilterManager;
 use UpdateTool\Util\ReleaseNode;
 use VersionTool\VersionTool;
 use UpdateTool\Util\SupportLevel;
+use UpdateTool\Util\ProjectUpdateTrait;
 
 /**
  * Commands used to manipulate projects directly with git
@@ -28,6 +29,7 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
     use ConfigAwareTrait;
     use LoggerAwareTrait;
     use ApiTrait;
+    use ProjectUpdateTrait;
 
     /**
      * Show the list of available versions already released for the specified project.
@@ -549,116 +551,8 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         'base-branch' => 'master',
     ])
     {
-        if (count(explode('/', $project)) != 2) {
-            throw new \Exception("Invalid project name: $project");
-        }
-        if (empty($options['codeowners']) && empty($options['support-level-badge'])) {
-            throw new \Exception("Must specify at least one of --codeowners or --support-level-badge");
-        }
-        $url = "git@github.com:$project.git";
-        $remote = new Remote($url);
         $api = $this->api($options['as']);
-        $dir = sys_get_temp_dir() . '/hubph/' . $remote->project();
-        $baseBranch = $options['base-branch'];
-        $workingCopy = WorkingCopy::cloneBranch($url, $dir, $baseBranch, $api);
-
-        if ($this->logger) {
-            $workingCopy->setLogger($this->logger);
-        }
-
-        $branchName = $options['branch-name'];
-        $workingCopy->createBranch($branchName);
-        $workingCopy->switchBranch($branchName);
-
-        if (!empty($options['codeowners'])) {
-            $codeowners = $options['codeowners'];
-            // Append given CODEOWNERS line.
-            file_put_contents("$dir/CODEOWNERS", '* ' . $codeowners . "\n", FILE_APPEND);
-            $workingCopy->add("$dir/CODEOWNERS");
-        }
-
-        if (!empty($options['support-level-badge'])) {
-            $support_level_badge = $options['support-level-badge'];
-            $badge_contents = SupportLevel::getSupportLevelBadge($support_level_badge);
-            if (!$badge_contents) {
-                throw new \Exception("Invalid support level badge: $support_level_badge.");
-            }
-            if (file_exists("$dir/README.md")) {
-                $readme_contents = file_get_contents("$dir/README.md");
-            } else {
-                $readme_contents = '';
-            }
-
-            $lines = explode("\n", $readme_contents);
-            [$badge_insert_line, $empty_line_after] = $this->getBadgeInsertLine($lines);
-
-            // Insert badge contents and empty line after it.
-            $insert = [$badge_contents];
-            if ($empty_line_after) {
-                $insert[] = '';
-            }
-            array_splice($lines, $badge_insert_line, 0, $insert);
-            $readme_contents = implode("\n", $lines);
-            file_put_contents("$dir/README.md", $readme_contents);
-            $workingCopy->add("$dir/README.md");
-        }
-
-        $commit_message = $options['commit-message'];
-        $workingCopy->commit($commit_message);
-        $workingCopy->push('origin', $branchName);
-        $message = $options['pr-title'];
-        $body = $options['pr-body'];
-        $workingCopy->pr($message, $body, $baseBranch, $branchName);
-    }
-
-    /**
-     * Get line number where to insert the badge.
-     */
-    protected function getBadgeInsertLine($readme_lines, $number_of_lines_to_search = 5)
-    {
-        $first_empty_line = -1;
-        $last_badge_line = -1;
-        $badge_insert_line = -1;
-        $empty_line_after = true;
-        foreach ($readme_lines as $line_number => $line) {
-            if ($first_empty_line == -1 && empty(trim($line))) {
-                $first_empty_line = $line_number;
-            }
-            // Is this line a badge?
-            if (preg_match('/\[\!\[[A-Za-z0-9\s]+\]\(.*\)/', $line)) {
-                $last_badge_line = $line_number;
-                // Is this line the License badge?
-                if (preg_match('/\[\!\[License]\(.*\)/', $line)) {
-                    if ($line_number) {
-                        $badge_insert_line = $line_number;
-                    } else {
-                        $badge_insert_line = 0;
-                    }
-                    $empty_line_after = false;
-                }
-            } else {
-                if ($last_badge_line != -1) {
-                    // We already found the badges, exit foreach.
-                    break;
-                } elseif ($line_number > $number_of_lines_to_search) {
-                    // We've searched enough lines, exit foreach.
-                    break;
-                }
-            }
-        }
-        if ($badge_insert_line === -1) {
-            if ($last_badge_line !== -1) {
-                // If we found badges, we'll insert this badge after the last badge.
-                $badge_insert_line = $last_badge_line + 1;
-            } elseif ($first_empty_line !== -1) {
-                // If we didn't find any badges, we'll insert this badge at the first empty line.
-                $badge_insert_line = $first_empty_line + 1;
-            } else {
-                // Final fallback: insert badge in the second line of the file.
-                $badge_insert_line = 1;
-            }
-        }
-        return [$badge_insert_line, $empty_line_after];
+        $this->updateProjectInfo($api, $project, $options['base-branch'], $options['branch-name'], $options['commit-message'], $options['pr-title'], $options['pr-body'], $this->logger, $options['support-level-badge'], $options['codeowners']);
     }
 
     /**

--- a/src/Util/ProjectUpdate.php
+++ b/src/Util/ProjectUpdate.php
@@ -86,6 +86,7 @@ class ProjectUpdate implements LoggerAwareInterface
             }
 
             if (!SupportLevel::compareSupportLevelFromReadmeAndBadge($readme_contents, $badge_contents)) {
+                $line_deleted = SupportLevel::deleteSupportLevelBadgesFromReadme($readme_contents, $supportLevelBadge);
                 $lines = explode("\n", $readme_contents);
                 [$badge_insert_line, $empty_line_after] = $this->getBadgeInsertLine($lines, $badge_contents);
 
@@ -94,7 +95,8 @@ class ProjectUpdate implements LoggerAwareInterface
                 if ($empty_line_after) {
                     $insert[] = '';
                 }
-                array_splice($lines, $badge_insert_line, 0, $insert);
+                $length = $line_deleted ? 1 : 0;
+                array_splice($lines, $badge_insert_line, $length, $insert);
                 $readme_contents = implode("\n", $lines);
                 file_put_contents("$dir/README.md", $readme_contents);
                 $workingCopy->add("$dir/README.md");

--- a/src/Util/ProjectUpdate.php
+++ b/src/Util/ProjectUpdate.php
@@ -5,14 +5,23 @@ namespace UpdateTool\Util;
 use UpdateTool\Git\Remote;
 use UpdateTool\Git\WorkingCopy;
 use UpdateTool\Util\SupportLevel;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 
-trait ProjectUpdateTrait
+class ProjectUpdate implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->setLogger($logger);
+    }
 
     /**
      * Update project info (codeowners and support level badge).
      */
-    protected function updateProjectInfo($api, $project, $baseBranch, $branchName, $commitMessage, $prTitle, $prBody, $logger, $supportLevelBadge = '', $codeowners = '')
+    public function updateProjectInfo($api, $project, $baseBranch, $branchName, $commitMessage, $prTitle, $prBody, $supportLevelBadge = '', $codeowners = '')
     {
         $branchToClone = $baseBranch;
         if (count(explode('/', $project)) != 2) {
@@ -42,7 +51,7 @@ trait ProjectUpdateTrait
 
         $workingCopy = WorkingCopy::cloneBranch($url, $dir, $branchToClone, $api);
 
-        $workingCopy->setLogger($logger);
+        $workingCopy->setLogger($this->logger);
 
         if (!$existingPrFound) {
             $workingCopy->createBranch($branchName);

--- a/src/Util/ProjectUpdateTrait.php
+++ b/src/Util/ProjectUpdateTrait.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace UpdateTool\Util;
+
+use UpdateTool\Cli\ApiTrait;
+use UpdateTool\Git\Remote;
+use UpdateTool\Git\WorkingCopy;
+
+trait ProjectUpdateTrait
+{
+
+    use ApiTrait;
+
+    /**
+     * Update project info (codeowners and support level badge).
+     */
+    protected function updateProjectInfo($api, $project, $baseBranch, $branchName, $commitMessage, $prTitle, $prBody, $logger, $supportLevelBadge = '', $codeowners = '')
+    {
+        if (count(explode('/', $project)) != 2) {
+            throw new \Exception("Invalid project name: $project");
+        }
+        if (empty($codeowners) && empty($supportLevelBadge)) {
+            throw new \Exception("Must specify at least one of codeowners or support-level-badge");
+        }
+        $url = "git@github.com:$project.git";
+        $remote = new Remote($url);
+        $dir = sys_get_temp_dir() . '/hubph/' . $remote->project();
+        $workingCopy = WorkingCopy::cloneBranch($url, $dir, $baseBranch, $api);
+
+        $workingCopy->setLogger($logger);
+
+        $workingCopy->createBranch($branchName);
+        $workingCopy->switchBranch($branchName);
+
+        if (!empty($codeowners)) {
+            // Append given CODEOWNERS line.
+            file_put_contents("$dir/CODEOWNERS", '* ' . $codeowners . "\n", FILE_APPEND);
+            $workingCopy->add("$dir/CODEOWNERS");
+        }
+
+        if (!empty($supportLevelBadge)) {
+            $badge_contents = SupportLevel::getSupportLevelBadge($supportLevelBadge);
+            if (!$badge_contents) {
+                throw new \Exception("Invalid support level badge: $supportLevelBadge.");
+            }
+            if (file_exists("$dir/README.md")) {
+                $readme_contents = file_get_contents("$dir/README.md");
+            } else {
+                $readme_contents = '';
+            }
+
+            $lines = explode("\n", $readme_contents);
+            [$badge_insert_line, $empty_line_after] = $this->getBadgeInsertLine($lines);
+
+            // Insert badge contents and empty line after it.
+            $insert = [$badge_contents];
+            if ($empty_line_after) {
+                $insert[] = '';
+            }
+            array_splice($lines, $badge_insert_line, 0, $insert);
+            $readme_contents = implode("\n", $lines);
+            file_put_contents("$dir/README.md", $readme_contents);
+            $workingCopy->add("$dir/README.md");
+        }
+
+        $workingCopy->commit($commitMessage);
+        $workingCopy->push('origin', $branchName);
+        $workingCopy->pr($prTitle, $prBody, $baseBranch, $branchName);
+    }
+
+    /**
+     * Get line number where to insert the badge.
+     */
+    protected function getBadgeInsertLine($readme_lines, $number_of_lines_to_search = 5)
+    {
+        $first_empty_line = -1;
+        $last_badge_line = -1;
+        $badge_insert_line = -1;
+        $empty_line_after = true;
+        foreach ($readme_lines as $line_number => $line) {
+            if ($first_empty_line == -1 && empty(trim($line))) {
+                $first_empty_line = $line_number;
+            }
+            // Is this line a badge?
+            if (preg_match('/\[\!\[[A-Za-z0-9\s]+\]\(.*\)/', $line)) {
+                $last_badge_line = $line_number;
+                // Is this line the License badge?
+                if (preg_match('/\[\!\[License]\(.*\)/', $line)) {
+                    if ($line_number) {
+                        $badge_insert_line = $line_number;
+                    } else {
+                        $badge_insert_line = 0;
+                    }
+                    $empty_line_after = false;
+                }
+            } else {
+                if ($last_badge_line != -1) {
+                    // We already found the badges, exit foreach.
+                    break;
+                } elseif ($line_number > $number_of_lines_to_search) {
+                    // We've searched enough lines, exit foreach.
+                    break;
+                }
+            }
+        }
+        if ($badge_insert_line === -1) {
+            if ($last_badge_line !== -1) {
+                // If we found badges, we'll insert this badge after the last badge.
+                $badge_insert_line = $last_badge_line + 1;
+            } elseif ($first_empty_line !== -1) {
+                // If we didn't find any badges, we'll insert this badge at the first empty line.
+                $badge_insert_line = $first_empty_line + 1;
+            } else {
+                // Final fallback: insert badge in the second line of the file.
+                $badge_insert_line = 1;
+            }
+        }
+        return [$badge_insert_line, $empty_line_after];
+    }
+
+}

--- a/src/Util/ProjectUpdateTrait.php
+++ b/src/Util/ProjectUpdateTrait.php
@@ -117,5 +117,4 @@ trait ProjectUpdateTrait
         }
         return [$badge_insert_line, $empty_line_after];
     }
-
 }

--- a/src/Util/ProjectUpdateTrait.php
+++ b/src/Util/ProjectUpdateTrait.php
@@ -2,14 +2,11 @@
 
 namespace UpdateTool\Util;
 
-use UpdateTool\Cli\ApiTrait;
 use UpdateTool\Git\Remote;
 use UpdateTool\Git\WorkingCopy;
 
 trait ProjectUpdateTrait
 {
-
-    use ApiTrait;
 
     /**
      * Update project info (codeowners and support level badge).

--- a/src/Util/ProjectUpdateTrait.php
+++ b/src/Util/ProjectUpdateTrait.php
@@ -24,7 +24,7 @@ trait ProjectUpdateTrait
         }
         $url = "git@github.com:$project.git";
         $remote = new Remote($url);
-        $dir = sys_get_temp_dir() . '/hubph/' . $remote->project();
+        $dir = sys_get_temp_dir() . '/update-tool/' . $remote->project();
         $workingCopy = WorkingCopy::cloneBranch($url, $dir, $baseBranch, $api);
 
         $workingCopy->setLogger($logger);

--- a/src/Util/ProjectUpdateTrait.php
+++ b/src/Util/ProjectUpdateTrait.php
@@ -54,8 +54,11 @@ trait ProjectUpdateTrait
         if (!empty($codeowners)) {
             // Append given CODEOWNERS line.
             $string_to_add = '* ' . $codeowners . "\n";
-            $codeownners_content = file_get_contents("$dir/CODEOWNERS");
-            if (strpos($codeownners_content, $string_to_add) === false) {
+            $codeowners_content = '';
+            if (file_exists("$dir/CODEOWNERS")) {
+                $codeowners_content = file_get_contents("$dir/CODEOWNERS");
+            }
+            if (strpos($codeowners_content, $string_to_add) === false) {
                 file_put_contents("$dir/CODEOWNERS", $string_to_add, FILE_APPEND);
                 $workingCopy->add("$dir/CODEOWNERS");
                 $codeowners_changed = true;

--- a/src/Util/ProjectUpdateTrait.php
+++ b/src/Util/ProjectUpdateTrait.php
@@ -45,8 +45,8 @@ trait ProjectUpdateTrait
         $workingCopy->setLogger($logger);
 
         if (!$existingPrFound) {
-          $workingCopy->createBranch($branchName);
-          $workingCopy->switchBranch($branchName);
+            $workingCopy->createBranch($branchName);
+            $workingCopy->switchBranch($branchName);
         }
         $codeowners_changed = false;
         $readme_changed = false;

--- a/src/Util/SupportLevel.php
+++ b/src/Util/SupportLevel.php
@@ -70,4 +70,40 @@ class SupportLevel
         $badges = self::getBadgesLabels();
         return $badges[$level] ?? '';
     }
+
+    /**
+     * Get support level from README.md contents.
+     */
+    public static function getSupportLevelFromContent($readme_contents)
+    {
+        $support_level = null;
+        $lines = explode("\n", $readme_contents);
+        $badges = SupportLevel::getSupportLevelBadges();
+        foreach ($lines as $line) {
+            foreach ($badges as $key => $badge) {
+                // Get the badge text from the badge markup.
+                preg_match(self::SUPPORT_LEVEL_BADGE_LABEL_REGEX, $badge, $matches);
+                if (!empty($matches[1])) {
+                    if (strpos($line, $matches[1]) !== false) {
+                        $support_level = $key;
+                        break 2;
+                    }
+                }
+            }
+        }
+        if ($support_level) {
+            return self::getSupportLevelLabel($support_level);
+        }
+        return null;
+    }
+
+    /**
+     * Compare support label from readme and badge.
+     */
+    public static function compareSupportLevelFromReadmeAndBadge($readme_contents, $badge_contents)
+    {
+        $support_level_from_readme = self::getSupportLevelFromContent($readme_contents);
+        $support_level_from_badge = self::getSupportLevelFromContent($badge_contents);
+        return $support_level_from_badge === $support_level_from_readme;
+    }
 }

--- a/src/Util/SupportLevel.php
+++ b/src/Util/SupportLevel.php
@@ -74,25 +74,31 @@ class SupportLevel
     /**
      * Get support level from README.md contents.
      */
-    public static function getSupportLevelFromContent($readme_contents)
+    public static function getSupportLevelsFromContent($contents, $return_only_first = false)
     {
         $support_level = null;
-        $lines = explode("\n", $readme_contents);
+        $lines = explode("\n", $contents);
         $badges = SupportLevel::getSupportLevelBadges();
+        $support_levels = [];
         foreach ($lines as $line) {
             foreach ($badges as $key => $badge) {
                 // Get the badge text from the badge markup.
                 preg_match(self::SUPPORT_LEVEL_BADGE_LABEL_REGEX, $badge, $matches);
                 if (!empty($matches[1])) {
                     if (strpos($line, $matches[1]) !== false) {
-                        $support_level = $key;
-                        break 2;
+                        $support_levels[$key] = $key;
                     }
                 }
             }
         }
-        if ($support_level) {
-            return self::getSupportLevelLabel($support_level);
+        if ($support_levels) {
+            foreach ($support_levels as $key => $support_level) {
+                $support_levels[$key] = self::getSupportLevelLabel($support_level);
+            }
+            if ($return_only_first) {
+                return reset($support_levels);
+            }
+            return $support_levels;
         }
         return null;
     }
@@ -102,8 +108,8 @@ class SupportLevel
      */
     public static function compareSupportLevelFromReadmeAndBadge($readme_contents, $badge_contents)
     {
-        $support_level_from_readme = self::getSupportLevelFromContent($readme_contents);
-        $support_level_from_badge = self::getSupportLevelFromContent($badge_contents);
-        return $support_level_from_badge === $support_level_from_readme;
+        $support_levels_from_readme = self::getSupportLevelsFromContent($readme_contents);
+        $support_levels_from_badge = self::getSupportLevelsFromContent($badge_contents);
+        return (bool) count(array_intersect($support_levels_from_readme, $support_levels_from_badge));
     }
 }

--- a/src/Util/SupportLevel.php
+++ b/src/Util/SupportLevel.php
@@ -8,6 +8,8 @@ namespace UpdateTool\Util;
 class SupportLevel
 {
 
+    const SUPPORT_LEVEL_BADGE_LABEL_REGEX = '/^\[\!\[([A-Za-z\s\d]+)\]\(https:\/\/img.shields.io/';
+
     /**
      * Get right badge markdown.
      */
@@ -52,7 +54,7 @@ class SupportLevel
         $badges = self::getSupportLevelBadges();
         $labels = [];
         foreach ($badges as $key => $badge) {
-            preg_match('/^\[\!\[([A-Za-z\s\d]+)\]\(https:\/\/img.shields.io/', $badge, $matches);
+            preg_match(self::SUPPORT_LEVEL_BADGE_LABEL_REGEX, $badge, $matches);
             if (!empty($matches[1])) {
                 $labels[$key] = $matches[1];
             }

--- a/src/Util/SupportLevel.php
+++ b/src/Util/SupportLevel.php
@@ -9,6 +9,7 @@ class SupportLevel
 {
 
     const SUPPORT_LEVEL_BADGE_LABEL_REGEX = '/^\[\!\[([A-Za-z\s\d]+)\]\(https:\/\/img.shields.io/';
+    const CURRENT_SUPPORT_LEVEL_BADGE_LABEL_REGEX = '/^\[\!\[NAME\]\(https:\/\/img\.shields\.io.*$/m';
 
     /**
      * Get right badge markdown.
@@ -100,7 +101,7 @@ class SupportLevel
             }
             return $support_levels;
         }
-        return null;
+        return [];
     }
 
     /**
@@ -110,6 +111,27 @@ class SupportLevel
     {
         $support_levels_from_readme = self::getSupportLevelsFromContent($readme_contents);
         $support_levels_from_badge = self::getSupportLevelsFromContent($badge_contents);
-        return (bool) count(array_intersect($support_levels_from_readme, $support_levels_from_badge));
+
+        return count($support_levels_from_readme) === 1 && count(array_intersect($support_levels_from_readme, $support_levels_from_badge));
+    }
+
+    /**
+     * Delete all support badges in README but the one given.
+     */
+    public static function deleteSupportLevelBadgesFromReadme(&$readme_contents, $preserve_badge = null)
+    {
+        $support_levels_from_readme = self::getSupportLevelsFromContent($readme_contents);
+        foreach ($support_levels_from_readme as $support_level) {
+            if ($support_level !== $preserve_badge) {
+                $pattern = str_replace('NAME', $support_level, self::CURRENT_SUPPORT_LEVEL_BADGE_LABEL_REGEX);
+                // Delete support level badge.
+                $return = preg_replace($pattern, '', $readme_contents);
+                if ($return) {
+                    $readme_contents = $return;
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/Util/SupportLevel.php
+++ b/src/Util/SupportLevel.php
@@ -14,7 +14,18 @@ class SupportLevel
     public static function getSupportLevelBadge($level)
     {
         $badges = self::getSupportLevelBadges();
-        return $badges[$level] ?? '';
+        $badge_contents = $badges[$level] ?? '';
+        if (!$badge_contents) {
+            // Try badge label.
+            $labels = self::getBadgesLabels();
+            foreach ($labels as $badge_name => $label) {
+                if (strpos($label, $level) !== false) {
+                    $badge_contents = $badges[$badge_name];
+                    break;
+                }
+            }
+        }
+        return $badge_contents;
     }
 
     /**
@@ -38,15 +49,15 @@ class SupportLevel
      */
     public static function getBadgesLabels()
     {
-        return [
-            'ea' => 'Early Access',
-            'la' => 'Limited Availability',
-            'active' => 'Actively Maintained',
-            'minimal' => 'Minimal Support',
-            'unsupported' => 'Unsupported',
-            'unofficial' => 'Unofficial',
-            'deprecated' => 'Deprecated',
-        ];
+        $badges = self::getSupportLevelBadges();
+        $labels = [];
+        foreach ($badges as $key => $badge) {
+            preg_match('/^\[\!\[([A-Za-z\s\d]+)\]\(https:\/\/img.shields.io/', $badge, $matches);
+            if (!empty($matches[1])) {
+                $labels[$key] = $matches[1];
+            }
+        }
+        return $labels;
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request adds a new command that takes a csv as argument and goes through all of the projects and update project info for each line.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Description
- Also accept badge label in the project:update-info command argument
- Adds org:update-projects-info command
- Refactor project:info-update into trait to make it reusable

### Notes
- I ran this command like this `./update-tool org:update-projects-info projects.csv --update-codeowners --update-support-level-badge` against this csv file: https://gist.github.com/kporras07/5daa2c67ba6ca8f808120a8e6234861c and it created this PR: https://github.com/kporras07/wordpress-network/pull/23/files