### PR TITLE
Use the right branch to push at the end of the command.

### DIFF
--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -298,13 +298,13 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         }
 
         // Add commits to main-branch from latest processed tag.
-        $project_working_copy->switchBranch($previous_version);
+        $project_working_copy->switchBranch($main_branch);
         $upstream_working_copy->switchBranch($latest_version);
         $this->logger->notice("Processing files from {upstream} {version} over {target} {previous}", ['upstream' => $upstream_repo->projectWithOrg(), 'version' => $latest_version, 'target' => $remote_repo->projectWithOrg(), 'previous' => $previous_version]);
         $this->applyFiltersAndCommit($filter_manager, $upstream_working_copy, $project_working_copy, $update_parameters);
         if (!empty($options['push'])) {
-            $this->logger->notice("Push branch {version} to {target}", ['version' => $previous_version, 'target' => $remote_repo->projectWithOrg()]);
-            $project_working_copy->push('origin', $previous_version);
+            $this->logger->notice("Push branch {version} to {target}", ['version' => $main_branch, 'target' => $remote_repo->projectWithOrg()]);
+            $project_working_copy->push('origin', $main_branch);
         }
     }
 


### PR DESCRIPTION
### Overview
This pull request fixes the branch to push at the end of the project:derivative:update command.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Switches to use main-branch as the branch to push at the end of the derivative update command.
