### PR TITLE
[CMS-491] Add body text to the PR for automated cos-php updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 * Remove rpmbuild-php (#45)
+* Add body text to the PR for automated cos-php updates (#47)
 
 ### 0.1.0 - 2018/May/26
 

--- a/src/Cli/PhpCommands.php
+++ b/src/Cli/PhpCommands.php
@@ -86,11 +86,12 @@ class PhpCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         }, $updated_versions));
         $preamble = $this->preamble();
         $message = "{$preamble}{$all_updated_versions}";
+        $body = "This automation creates the PHP upgrade PR about two days before the versions are actually released. We should wait until the release is visible on https://www.php.net/ before merging.";
 
         // Determine if there are any PRs already open that we should
         // close. There should be no more than one. If its contents are the
         // same, then we should abort rather than create the same PR again.
-        // If the cnotents are different, then we'll make a new PR and close
+        // If the contents are different, then we'll make a new PR and close
         // this one.
         $prs = $api->matchingPRs($cos_php->projectWithOrg(), $preamble, '');
         if (in_array($message, $prs->titles())) {
@@ -108,7 +109,7 @@ class PhpCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
             ->add('PHP_VERSIONS')
             ->commit($message)
             ->push()
-            ->pr($message);
+            ->pr($message, $body);
 
         $comment = sprintf('Superseeded by #%s.', $pr['number']);
 


### PR DESCRIPTION
### Overview
This pull request:
Add body text to the PR for automated cos-php updates.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Add body text to the PR for automated cos-php updates.

### Description
I prematurely merged an automated PHP patch version update before the new patch version had been actually released.  This change adds a reminder message to future engineers to wait two days for the announcement to appear on the php.net website.