### PR TITLE
[CMS-451] Exclude complete command that causes errors in docs build.

### DIFF
--- a/src/Cli/UpdateTerminusDocsCommands.php
+++ b/src/Cli/UpdateTerminusDocsCommands.php
@@ -85,6 +85,16 @@ class UpdateTerminusDocsCommands extends \Robo\Tasks implements ConfigAwareInter
             }
 
             $commands = json_decode(file_get_contents($dir . '/source/data/commands.json'), true);
+
+            // Remove _complete command that makes the build break.
+            foreach ($commands['commands'] as $key => $command) {
+                if ($command['name'] === '_complete') {
+                    unset($commands['commands'][$key]);
+                    break;
+                }
+            }
+            $commands['commands'] = array_values($commands['commands']);
+
             $commandsJson = json_encode($commands, JSON_PRETTY_PRINT);
 
             // Adjust output.


### PR DESCRIPTION
### Overview
This pull request fixes build error in documentation repo.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
_complete command was causing the docs build process to break. This PR removes that command from the commands.json file.

