### PR TITLE
[CMS-451] Avoid creating lots of PRs and get the search and replace working correctly.

### DIFF
--- a/src/Cli/UpdateTerminusDocsCommands.php
+++ b/src/Cli/UpdateTerminusDocsCommands.php
@@ -168,7 +168,8 @@ class UpdateTerminusDocsCommands extends \Robo\Tasks implements ConfigAwareInter
     /**
      * Get preamble string for PR title.
      */
-    protected function preamble($prTitle) {
+    protected function preamble($prTitle)
+    {
         if ($position = strpos($prTitle, '%version')) {
             return substr($prTitle, 0, $position);
         }
@@ -177,7 +178,8 @@ class UpdateTerminusDocsCommands extends \Robo\Tasks implements ConfigAwareInter
     /**
      * Get final PR title based on version.
      */
-    protected function getFinalPrTitle($prTitle, $version) {
+    protected function getFinalPrTitle($prTitle, $version)
+    {
         return str_replace('%version', $version, $prTitle);
     }
 


### PR DESCRIPTION
### Overview
This pull request improves the terminus:update-docs command.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
- Fixes search and replace logic for site_env.
- Avoids daily PR creation if same Terminus release.

