### PR TITLE
[CMS-451] Add default pr-body value.

### DIFF
--- a/src/Cli/UpdateTerminusDocsCommands.php
+++ b/src/Cli/UpdateTerminusDocsCommands.php
@@ -33,7 +33,7 @@ class UpdateTerminusDocsCommands extends \Robo\Tasks implements ConfigAwareInter
         'base-branch' => 'main',
         'branch-name-prefix' => 'docs-update-terminus-',
         'commit-message' => 'Update terminus information.',
-        'pr-body' => '',
+        'pr-body' => '[UpdateTool - Terminus Information] Update commands and releases to the latest Terminus version.',
         'pr-title' => '[UpdateTool - Terminus Information] Update commands and releases to version %version.',
         'dry-run' => false,
     ])


### PR DESCRIPTION
### Overview
This pull request adds default pr-body to terminus:update-docs command. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Adds default PR body text to update-docs command.

### Description
This prevents a script from the docs team to fail because of empty PRs bodies.