### PR TITLE
CMS-584: Updates to org:update-projects-info command.

### DIFF
--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -165,6 +165,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         'update-support-level-badge' => false,
         'branch-name' => 'project-update-info',
         'commit-message' => 'Update project information.',
+        'error-log-file' => 'error.log',
         'pr-body' => '',
         'pr-title' => '[UpdateTool - Project Information] Update project information.',
     ])
@@ -245,6 +246,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                     try {
                         $projectUpdate->updateProjectInfo($api, $projectFullName, $projectDefaultBranch, $options['branch-name'], $options['commit-message'], $options['pr-title'], $options['pr-body'], $projectSupportLevel, $codeowners);
                     } catch (\Exception $e) {
+                        $this->writeToLogFile($projectFullName, $options['error-log-file']);
                         $this->logger->warning("Failed to update project information for $projectFullName: " . $e->getMessage());
                     }
                 }
@@ -253,6 +255,18 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         } else {
             throw new \Exception("File $csv_file does not exist.");
         }
+    }
+
+    /**
+     * Write to log file.
+     */
+    protected function writeToLogFile($message, $filename) {
+        $contents = '';
+        if (file_exists($filename)) {
+            $contents = file_get_contents($filename);
+        }
+        $contents .= $message . "\n";
+        file_put_contents($filename, $contents);
     }
 
     /**

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -223,7 +223,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                     if ($projectUpdateSupportLevel && (empty($projectSupportLevel) || !$this->validateProjectSupportLevel($projectSupportLevel))) {
                         $projectUpdateSupportLevel = false;
                         if ($options['skip-on-empty-support-level']) {
-                            $this->logger->warning("Skipping project $projectFullName because of empty or invalid support level.");
+                            $this->logger->warning(sprintf("Skipping project %s because of empty or invalid support level.", $projectFullName));
                             continue;
                         }
                     }

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -166,6 +166,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         'branch-name' => 'project-update-info',
         'commit-message' => 'Update project information.',
         'error-log-file' => 'error.log',
+        'skip-on-empty-support-level' => TRUE,
         'pr-body' => '',
         'pr-title' => '[UpdateTool - Project Information] Update project information.',
     ])
@@ -220,6 +221,10 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                     // If empty or invalid support level, we won't update it here.
                     if ($projectUpdateSupportLevel && (empty($projectSupportLevel) || !$this->validateProjectSupportLevel($projectSupportLevel))) {
                         $projectUpdateSupportLevel = false;
+                        if ($options['skip-on-empty-support-level']) {
+                            $this->logger->warning("Skipping project $projectFullName because of empty or invalid support level.");
+                            continue;
+                        }
                     }
                     if ($projectUpdateCodeowners) {
                         list($codeowners, $ownerSource) = $this->guessCodeowners($api, $projectOrg, $projectFullName);

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -162,6 +162,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         'update-codeowners' => false,
         'codeowners-only-api' => false,
         'codeowners-only-guess' => false,
+        'codeowners-only-owner' => '',
         'update-support-level-badge' => false,
         'branch-name' => 'project-update-info',
         'commit-message' => 'Update project information.',
@@ -238,6 +239,9 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                             } else {
                                 $codeowners = implode('\n', $codeowners);
                             }
+                        }
+                        if ($options['codeowners-only-owner'] && $codeowners !== $options['codeowners-only-owner']) {
+                            $codeowners = '';
                         }
                     }
                 } else {

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -167,7 +167,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         'branch-name' => 'project-update-info',
         'commit-message' => 'Update project information.',
         'error-log-file' => 'error.log',
-        'skip-on-empty-support-level' => TRUE,
+        'skip-on-empty-support-level' => true,
         'pr-body' => '',
         'pr-title' => '[UpdateTool - Project Information] Update project information.',
     ])
@@ -269,7 +269,8 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
     /**
      * Write to log file.
      */
-    protected function writeToLogFile($message, $filename) {
+    protected function writeToLogFile($message, $filename)
+    {
         $contents = '';
         if (file_exists($filename)) {
             $contents = file_get_contents($filename);


### PR DESCRIPTION
### Overview
This pull request makes some adjustments to org:update-projects-info command.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary

New options added to this command:
- skip-on-empty-support-level
- error-log-file
- codeowners-only-owner

### Description

- If asked to update support level and an invalid support level was provided, skip the row at all using the new "skip-on-empty-support-level" option.
- Logs failing repo names to a log file specified in new "error-log-file" option.
- Allow updating CODEOWNERS conditionally to only update it if given owner guessed by using the new "codeowners-only-owner" option.