### PR TITLE
[CMS-600] Add new options and improve support level handling in org:analyze command.

### DIFF
--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -74,7 +74,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         'as' => 'default',
         'format' => 'table',
         'only-public' => false,
-        'no-forks' => false,
+        'forks' => true,
     ])
     {
         $api = $this->api($options['as']);
@@ -96,7 +96,7 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         }
 
         // Remove fork repos.
-        if ($options['no-forks']) {
+        if (!$options['forks']) {
             $repos = array_filter($repos, function ($repo) {
                 return empty($repo['fork']);
             });

--- a/src/Cli/OrgCommands.php
+++ b/src/Cli/OrgCommands.php
@@ -70,7 +70,12 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
      *
      * @return Consolidation\OutputFormatters\StructuredData\RowsOfFields
      */
-    public function orgAnalyze($org, $options = ['as' => 'default', 'format' => 'table'])
+    public function orgAnalyze($org, $options = [
+        'as' => 'default',
+        'format' => 'table',
+        'only-public' => false,
+        'no-forks' => false,
+    ])
     {
         $api = $this->api($options['as']);
         $pager = $api->resultPager();
@@ -82,6 +87,20 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         $repos = array_filter($repos, function ($repo) {
             return empty($repo['archived']);
         });
+
+        // Remove private repos.
+        if ($options['only-public']) {
+            $repos = array_filter($repos, function ($repo) {
+                return empty($repo['private']);
+            });
+        }
+
+        // Remove fork repos.
+        if ($options['no-forks']) {
+            $repos = array_filter($repos, function ($repo) {
+                return empty($repo['fork']);
+            });
+        }
 
         // TEMPORARY: only do the first 20
         // $repos = array_splice($repos, 0, 20);
@@ -106,9 +125,11 @@ class OrgCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
                 $data = $api->gitHubAPI()->api('repo')->contents()->show($org, $repo['name'], 'README.md');
                 if (!empty($data['content'])) {
                     $content = base64_decode($data['content']);
-                    $repo['support_level'] = SupportLevel::getSupportLevelsFromContent($content, true);
+                    $support_level = SupportLevel::getSupportLevelsFromContent($content);
+                    $repo['support_level'] = count($support_level) ? reset($support_level) : 'EMPTY';
                 }
             } catch (\Exception $e) {
+                $repo['support_level'] = 'EMPTY';
             }
 
             $reposResult[$resultKey] = $repo;

--- a/src/Util/SupportLevel.php
+++ b/src/Util/SupportLevel.php
@@ -86,7 +86,7 @@ class SupportLevel
                 // Get the badge text from the badge markup.
                 preg_match(self::SUPPORT_LEVEL_BADGE_LABEL_REGEX, $badge, $matches);
                 if (!empty($matches[1])) {
-                    if (strpos($line, $matches[1]) !== false) {
+                    if (stripos($line, $matches[0]) !== false) {
                         $support_levels[$key] = $key;
                     }
                 }


### PR DESCRIPTION
### Overview
This pull request adds new options to org:analyze command and fixes issues handling support_level field.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
- Added --no-forks option
- Added --only-public option
- Fixes support_level field handling

### Description

With this command executed like shown below, we could get a list of all public repos and their corresponding support level:

```
./update-tool org:analyze pantheon-systems --fields=full_name,support_level --no-forks --only-public
```

Then, if we use tools like wc and grep we could get counts really easily:

1) With this command you can get the total public repos under the given org:

```
./update-tool org:analyze pantheon-systems --fields=full_name,support_level --no-forks --only-public | grep pantheon-systems | wc -l
```

2) With this command you can get the total public repos with EMPTY support level:

```
./update-tool org:analyze pantheon-systems --fields=full_name,support_level --no-forks --only-public | grep EMPTY | wc -l
```

3) Then, calculating the coverage percentage for support-level badge will be:

coverage = (total_repos - empty) * 100 / total_repos

Example:
total_repos = 174
empty = 167
coverage = (174 - 167) * 100 / 174
coverage = 4.02%
