### PR TITLE
[CMS-571] Close old PRs for project:upstream:update based on upstream preamble.

### DIFF
--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -393,6 +393,7 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         $upstream_label = ucfirst($upstream);
         $message = $this->getConfig()->get("projects.$remote.upstream.update-message", 'Update to ' . $upstream_label . ' ' . $latest . '.');
         $message = str_replace('{version}', $latest, $message);
+        $preamble = $this->getConfig()->get("projects.$remote.upstream.update-preamble", '');
 
         // If we can find a release node, then add the "more information" blerb.
         $releaseNode = new ReleaseNode($api);
@@ -409,6 +410,11 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         if (!empty($existingPRList)) {
             $this->logger->notice("Pull request already exists for available update {latest}; nothing more to do.", ['latest' => $latest]);
             return;
+        }
+
+        // Now search for PRs based on preamble if it was set.
+        if ($preamble) {
+            $prs = $api->matchingPRs($remote_repo->projectWithOrg(), $preamble, '');
         }
 
         $this->logger->notice("Updating {remote} from {current} to {latest}", ['remote' => $remote, 'current' => $current, 'latest' => $latest]);

--- a/update-tool.yml
+++ b/update-tool.yml
@@ -262,6 +262,7 @@ projects:
       project: drupal
       major: 9
       update-method: SingleCommit
+      update-preamble: "Update to Drupal 9"
       update-parameters:
         allow-pre-release: false
         platform-additions:


### PR DESCRIPTION
Tested with this PR: https://github.com/pantheon-systems/drops-8/pull/405

Note: I'll be closing it soon so that regular updatinator reopens it with the right user.