### PR TITLE
Update version-pattern number for new major WP release

### DIFF
--- a/update-tool.yml
+++ b/update-tool.yml
@@ -117,7 +117,7 @@ projects:
     path: ${working-copy-path}/wordpress-composer
     source:
       project: wp
-      version-pattern: '^5'
+      version-pattern: '^5||^6'
       update-parameters:
         rsync:
           options: '-ravz --delete'
@@ -135,7 +135,7 @@ projects:
     main-branch: master
     source:
       project: wp
-      version-pattern: '^5'
+      version-pattern: '^5||^6'
       branch: master
   drops-7-composer:
     repo: git@github.com:pantheon-systems/drops-7-composer.git


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Description
WordPress 6.0 was released earlier, and the [derivative check](https://app.circleci.com/pipelines/github/pantheon-systems/updatinator/54253/workflows/30a0e471-1a0d-4afb-bde9-9e3d4f6011a4/jobs/72687) is not detecting the new update.

Before/after this change was implemented locally:

<img width="694" alt="Screen Shot 2022-05-24 at 5 10 19 PM" src="https://user-images.githubusercontent.com/17913282/170146412-9a827180-1031-4632-b801-d632f873a8cd.png">

