### PR TITLE
Add body to PR for plugins

### DIFF
--- a/src/Cli/PluginCommands.php
+++ b/src/Cli/PluginCommands.php
@@ -67,6 +67,7 @@ class PluginCommands extends \Robo\Tasks implements ConfigAwareInterface, Logger
 
         $preamble = $this->preamble($remote);
         $message = "{$preamble} to {$version_updates}";
+        $body = "It's intentional that the version(s) being updated to, {$version_updates}, are not the latest version(s) available.";
         // Determine if there are any PRs already open that we should
         // close. If its contents are the same, then we should abort rather than create the same PR again.
         // If the contents are different, then we'll make a new PR and close this one.
@@ -87,7 +88,7 @@ class PluginCommands extends \Robo\Tasks implements ConfigAwareInterface, Logger
             ->add($file_to_check)
             ->commit($message)
             ->push()
-            ->pr($message, '', $main_branch);
+            ->pr($message, $body, $main_branch);
 
         // Once we create a new PR, we can close the existing PRs.
         $api->prClose($plugin_working_copy->org(), $plugin_working_copy->project(), $prs);


### PR DESCRIPTION
### Overview
This pull request:
Adds a body to the PR that is generated for plugins.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 


### Description
The one plugin that runs in this section, wp-launch-check, bumps the WP core version.  When the major/minor versions that are available right now are 6.0 and 6.0.1, it was odd to see a PR bump the version to 6.0 and 5.9.4.