### PR TITLE
Add --ignore-whitespace option to patch command.

### DIFF
--- a/src/Update/Methods/DiffPatch.php
+++ b/src/Update/Methods/DiffPatch.php
@@ -68,8 +68,8 @@ class DiffPatch implements UpdateMethodInterface, LoggerAwareInterface
         // Apply the diff as a patch
         $tmpfname = tempnam(sys_get_temp_dir(), "diff-patch-" . $parameters['meta']['current-version'] . '-' . $this->latest . '.tmp');
         file_put_contents($tmpfname, $diffContents . "\n");
-        $this->logger->notice('patch -d {file} --no-backup-if-mismatch -Nutp1 < {tmpfile}', ['file' => $this->originalProject->dir(), 'tmpfile' => $tmpfname]);
-        passthru('patch -d ' .  $this->originalProject->dir() . ' --no-backup-if-mismatch -Nutp1 < ' . $tmpfname, $exitCode);
+        $this->logger->notice('patch -d {file} --no-backup-if-mismatch --ignore-whitespace -Nutp1 < {tmpfile}', ['file' => $this->originalProject->dir(), 'tmpfile' => $tmpfname]);
+        passthru('patch -d ' .  $this->originalProject->dir() . ' --no-backup-if-mismatch --ignore-whitespace -Nutp1 < ' . $tmpfname, $exitCode);
         if ($exitCode !== 0) {
             throw new \Exception("Failed to apply diff as patch");
         }


### PR DESCRIPTION
### Overview
This pull request adds --ignore-whitespace option to patch command.

From man page for patch:
```
-l  or  --ignore-whitespace
          Match patterns loosely, in case tabs or spaces have been munged in your files.  Any sequence of one or more blanks in the patch file matches any sequence in the original file, and
          sequences of blanks at the ends of lines are ignored.  Normal characters must still match exactly.  Each line of the context must still match a line in the original file.
```

The error was in a patch line that was removing a trailing whitespace
