### PR TITLE
[BUGS-6290] Clear untracked files between tag loops

### DIFF
--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -405,6 +405,9 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
                 $this->logger->notice("Skipping {version} because it is the latest tag in the source and should be handled by another job.", ['version' => $version]);
                 continue;
             }
+
+            // Make sure our working directory is cleaned up. An "untracked working tree files" error will fail checkout silently.
+            $project_working_copy->clean();
             // Checkout previous tag.
             $project_working_copy->checkout($previous);
 

--- a/src/Git/WorkingCopy.php
+++ b/src/Git/WorkingCopy.php
@@ -608,4 +608,12 @@ class WorkingCopy implements LoggerAwareInterface
     {
         return $this->execWithRedaction('git {dir}' . $cmd, ['dir' => "-C {$this->dir} "] + $replacements, ['dir' => ''] + $redacted);
     }
+
+    /**
+     * Clean untracked files
+     */
+    public function clean($flags = '-df')
+    {
+        $this->git('clean {flags}', ['flags' => $flags]);
+    }
 }


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Fixes silent failure on git checkout during the upstream:push-tags caused but untracked files when switching between versions.

### Description
- Addresses [BUGS-6290](https://getpantheon.atlassian.net/browse/BUGS-6290)
- Addresses https://github.com/pantheon-systems/WordPress/issues/364
- Dry-run tested with @kporras07 in CircleCI


[BUGS-6290]: https://getpantheon.atlassian.net/browse/BUGS-6290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ