### PR TITLE
Handle missing php7.4 version

### DIFF
--- a/src/Cli/PhpCommands.php
+++ b/src/Cli/PhpCommands.php
@@ -168,7 +168,6 @@ class PhpCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
     {
         $urlTemplate = $this->getConfig()->get('php-net.download-url');
         $url = str_replace('{version}', $version, $urlTemplate);
-        // $this->say(var_dump($url));
         // If the $url points to a local cache, use file_exists
         if ((strpos($url, 'file:///') !== false) || (strpos($url, '://') === false)) {
             return file_exists($url);

--- a/src/Cli/PhpCommands.php
+++ b/src/Cli/PhpCommands.php
@@ -168,7 +168,7 @@ class PhpCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
     {
         $urlTemplate = $this->getConfig()->get('php-net.download-url');
         $url = str_replace('{version}', $version, $urlTemplate);
-
+        // $this->say(var_dump($url));
         // If the $url points to a local cache, use file_exists
         if ((strpos($url, 'file:///') !== false) || (strpos($url, '://') === false)) {
             return file_exists($url);
@@ -205,6 +205,10 @@ class PhpCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         }
         $next_version = $version;
         $try_version = $this->nextVersion($version);
+        if ( $try_version == "7.4.31" ) {
+            // 7.4.31 DNE. Go Figure.
+            $try_version = $this->nextVersion($try_version);
+        }
         while ($this->versionExists($try_version)) {
             $next_version = $try_version;
             $try_version = $this->nextVersion($next_version);

--- a/src/Cli/PhpCommands.php
+++ b/src/Cli/PhpCommands.php
@@ -205,7 +205,7 @@ class PhpCommands extends \Robo\Tasks implements ConfigAwareInterface, LoggerAwa
         }
         $next_version = $version;
         $try_version = $this->nextVersion($version);
-        if ( $try_version == "7.4.31" ) {
+        if ($try_version == "7.4.31") {
             // 7.4.31 DNE. Go Figure.
             $try_version = $this->nextVersion($try_version);
         }


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes

### Summary
PHP 7.4.31 DNE, so update tool stopped looking when not found

### Description
We are not actually automating 7.4 on the master branch, but making the change as I would like to use this to test updates to updatinator.