### PR TITLE
[CMSP-674] adding more files/folders to remove from cloned mu-plugin

### DIFF
--- a/src/Update/Filters/CopyMuPlugin.php
+++ b/src/Update/Filters/CopyMuPlugin.php
@@ -55,8 +55,12 @@ class CopyMuPlugin implements UpdateFilterInterface, LoggerAwareInterface
         // Clean up the old and unnecessary files in mu-plugins.
         $files_to_delete = [
             "$dest/.git",
+            "$dest/.github",
+            "$dest/.gitattributes",
+            "$dest/.phpcs.xml",
             "$dest/README.md",
             "$dest/composer.json",
+            "$dest/CONTRIBUTING.md",
         ];
         foreach ($files_to_delete as $file) {
             $this->logger->notice('Removing {file}', ['file' => $file]);


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Adds additional files to exclude after the mu-plugin is cloned.

### Description
https://github.com/pantheon-systems/pantheon-mu-plugin/pull/25 adds additional files to the `pantheon-mu-plugin` that are not needed when the repository is cloned by Updatinator and are excluded from releases (as of that PR). This PR removes those files after the repository is cloned so we don't have CI or other unnecessary files in customer installs.
