### PR TITLE
[CMSP-633] exclude the files that are added in mu-plugin version 1.2.1

### DIFF
--- a/src/Update/Filters/CopyMuPlugin.php
+++ b/src/Update/Filters/CopyMuPlugin.php
@@ -58,9 +58,12 @@ class CopyMuPlugin implements UpdateFilterInterface, LoggerAwareInterface
             "$dest/.github",
             "$dest/.gitattributes",
             "$dest/.phpcs.xml",
+            "$dest/phpunit.xml.dist",
             "$dest/README.md",
             "$dest/composer.json",
             "$dest/CONTRIBUTING.md",
+            "$dest/bin",
+            "$dest/tests",
         ];
         foreach ($files_to_delete as $file) {
             $this->logger->notice('Removing {file}', ['file' => $file]);


### PR DESCRIPTION
### Overview
This pull request:

Excludes files that are added in https://github.com/pantheon-systems/pantheon-mu-plugin/pull/26 of the Pantheon mu-plugin.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
https://github.com/pantheon-systems/pantheon-mu-plugin/pull/26 adds new files in `/bin` and `/tests` as well as adding a new `phpunit.xml.dist` file. This excludes them in the workflow that copies the mu-plugin from the repository to the WordPress upstream.
