### PR TITLE
[CMSP-726] add the permissions to write the release to the repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
   repository_dispatch:
     types: [tests-passed]
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Overview
This pull request: updates the `publish.yml` workflow to apply the appropriate permissions to the GitHub bot to write changes to itself for GitHub Enterprise

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

