### PR TITLE
[CMSP-881] use version_compare

### DIFF
--- a/src/Cli/FrameworkCommands.php
+++ b/src/Cli/FrameworkCommands.php
@@ -299,7 +299,7 @@ class FrameworkCommands extends \Robo\Tasks implements ConfigAwareInterface, Log
 
         // If our versions do not match, check that the latest version exists before continuing.
         // Greater than comparision to ensure that we don't get older versions. See https://github.com/pantheon-systems/cos-framework-clis/pull/76#issuecomment-1118650316
-        if (version_compare($latest_version, $current_version)) {
+        if (version_compare($latest_version, $current_version, '>')) {
             $try_version = $this->wpVersionExists($latest_version);
 
             if (!empty($try_version)) {

--- a/src/Cli/FrameworkCommands.php
+++ b/src/Cli/FrameworkCommands.php
@@ -80,7 +80,7 @@ class FrameworkCommands extends \Robo\Tasks implements ConfigAwareInterface, Log
             $versions_file_path = "$work_dir/wpcli/Dockerfile";
             $version_file_contents = file_get_contents($versions_file_path);
             $version = $this->getCosWpCliVersion($version_file_contents);
-            
+
             $updated_version = '';
             $next_version = $this->nextWpVersionThatExists($version);
             if (!$next_version) {
@@ -299,7 +299,7 @@ class FrameworkCommands extends \Robo\Tasks implements ConfigAwareInterface, Log
 
         // If our versions do not match, check that the latest version exists before continuing.
         // Greater than comparision to ensure that we don't get older versions. See https://github.com/pantheon-systems/cos-framework-clis/pull/76#issuecomment-1118650316
-        if ($latest_version > $current_version) {
+        if (version_compare($latest_version, $current_version)) {
             $try_version = $this->wpVersionExists($latest_version);
 
             if (!empty($try_version)) {


### PR DESCRIPTION
### Overview
This pull request: 
* changes the `>` for comparing WP-CLI versions to `version_compare` 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no| Has tests?    | yes/no
| BC breaks?    | no     
| Deprecations? | yes/no (2.10 is no longer < 2.9? 🧌)

### Summary
`>` does not work when 2.10 is equivalent to 2.1 instead of the next value after 2.9.

`version_compare` is more robust and purpose-built for this use case.
