### PR TITLE
remove trailing space

### DIFF
--- a/src/Util/ReleaseNode.php
+++ b/src/Util/ReleaseNode.php
@@ -146,7 +146,7 @@ class ReleaseNode
 
     protected function matchesVersion($title, $version)
     {
-        return empty($version) || (strstr($title, " $version ") !== false);
+        return empty($version) || (strstr($title, " $version") !== false);
     }
 
     protected function getProjectAttribute($config, $remote, $name)


### PR DESCRIPTION
### Overview
This pull request:
Removes the trailing space when checking release version numbers (in case there is nothing in the announcement post title after the version)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

