### PR TITLE
allow php-http/discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
         "sort-packages": true,
         "platform": {
             "php": "7.1.13"
+        },
+        "allow-plugins": {
+            "php-http/discovery": true
         }
     },
     "extra": {


### PR DESCRIPTION
### Overview
This pull request:
Allows a composer plugin so the `composer release` script can run properly.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 
