### PR TITLE
define the tag in the release-action step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Publish Release
         uses: ncipollo/release-action@v1
         with:
+          tag: ${{ env.tag_name }}
           artifacts: 'update-tool.phar'
           artifactErrorsFailBuild: true
           body: Version ${{ env.tag_name }}


### PR DESCRIPTION
### Overview
This pull request:
adds a `tag` value so when we hand-off to this workflow from the test the `release-action` knows what tag to use (since it's not in the `ref`).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 
