### PR TITLE
Changing phpcs file name in mu plugin

### DIFF
--- a/src/Update/Filters/CopyMuPlugin.php
+++ b/src/Update/Filters/CopyMuPlugin.php
@@ -57,13 +57,13 @@ class CopyMuPlugin implements UpdateFilterInterface, LoggerAwareInterface
             "$dest/.git",
             "$dest/.github",
             "$dest/.gitattributes",
-            "$dest/.phpcs.xml",
             "$dest/phpunit.xml.dist",
             "$dest/README.md",
             "$dest/composer.json",
             "$dest/CONTRIBUTING.md",
             "$dest/bin",
             "$dest/tests",
+            "$dest/phpcs.xml",
         ];
         foreach ($files_to_delete as $file) {
             $this->logger->notice('Removing {file}', ['file' => $file]);


### PR DESCRIPTION
Moving phpcs.xml to a file codacy expects. Need to now ignore the correct file in update tool.