### PR TITLE
Removes `drops-7-composer` from Update Tool

### DIFF
--- a/update-tool.yml
+++ b/update-tool.yml
@@ -136,15 +136,6 @@ projects:
       project: wp
       version-pattern: '^5||^6'
       branch: master
-  drops-7-composer:
-    repo: git@github.com:pantheon-systems/drops-7-composer.git
-    path: ${working-copy-path}/drops-7-composer
-    source:
-      project: drops-7
-      version-pattern: '^7'
-      update-filters:
-        - RsyncFromSource
-        - CopyTemplateAdditions
   drops-8-scaffolding:
     repo: git@github.com:pantheon-systems/drops-8-scaffolding.git
     path: ${working-copy-path}/drops-8-scaffolding


### PR DESCRIPTION
Drops 7 Composer is not supported in D7 LTS.

This workflow is causing the CircleCI jobs to fail (see https://app.circleci.com/pipelines/github/pantheon-systems/updatinator/117551/workflows/c35bf47b-ea24-4384-84b3-71c7ee8f0ff6/jobs/205904) which is preventing WordPress derivatives like `wordpress-composer` and `wordpress-project` from receiving their updates.

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no  (fixes a deprecation)

